### PR TITLE
Add a switch on the bucket policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -187,20 +187,15 @@ resource "aws_cloudfront_distribution" "this" {
       max_ttl     = try(ordered_cache_behavior.value.max_ttl, var.max_ttl)
       compress    = try(ordered_cache_behavior.value.compress, var.compress)
 
+      forwarded_values {
+        query_string = var.forwarded_values_query_string
+
+        cookies {
+          forward = var.forwarded_values_cookies
+        }
+      }
+
       # NOTE: Depends on the optional variable
-      # dynamic "forwarded_values" {
-      #   for_each = ordered_cache_behavior.value.forwarded_values
-
-      #   content {
-      #     query_string = forwarded_values.value.query_string
-      #     headers      = forwarded_values.value.forward_header_values
-
-      #     cookies {
-      #       forward = forwarded_values.value.forward_cookies
-      #     }
-      #   }
-      # }
-
       # dynamic "lambda_function_association" {
       #   for_each = ordered_cache_behavior.value.lambda_function_association
 

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "aws_cloudfront_origin_access_identity" "this" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_s3_bucket_policy" "this" {
+  count  = var.enable_bucket_policy == true ? 1 : 0
   bucket = var.bucket_id
   policy = data.aws_iam_policy_document.this.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -142,6 +142,48 @@ variable "forwarded_values_cookies" {
   default     = "none"
 }
 
+# Ordered cache variables
+variable "ordered_cache_behaviors" {
+  description = <<EOF
+An ordered list of cache behaviors resource for this distribution. List from top
+to bottom in order of precedence. Array element's index is used to define the
+precedence.
+EOF
+
+  type = list(
+    object({
+      target_origin_id = string
+      path_pattern     = string
+
+      # TODO: Optional will be available in TF 0.15
+      # allowed_methods = optional(list(string))
+      # cached_methods  = optional(list(string))
+      # compress        = optional(bool)
+
+      # viewer_protocol_policy = optional(string)
+      # min_ttl                = optional(number)
+      # default_ttl            = optional(number)
+      # max_ttl                = optional(number)
+
+      # forward_query_string  = optional(bool)
+      # forward_header_values = optional(list(string))
+      # forward_cookies       = optional(string)
+
+      # lambda_function_association = optional(
+      #   list(
+      #     object({
+      #       event_type   = string
+      #       include_body = bool
+      #       lambda_arn   = string
+      #     })
+      #   )
+      # )
+    })
+  )
+
+  default = []
+}
+
 # Origin variables
 variable "origin_path" {
   description = "The parent path within the S3 bucket from which to serve content.  Do not use /, this is implied.  Useful for updating the distribution with a new version by using directories for versioning instead of invalidation requests"
@@ -149,11 +191,64 @@ variable "origin_path" {
   default     = null
 }
 
+variable "custom_origins" {
+  description = <<EOF
+  Array of custom origins to append to this CloudFront distribution.
+  Further info available at Terraform doc
+  Ref: https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#origin-arguments
+EOF
+
+  type = list(
+    object({
+      domain_name = string
+      origin_id   = string
+
+      # TODO: Optional attributes are going to be release in TF 0.15
+      # Ref: https://www.terraform.io/docs/language/functions/defaults.html
+
+      # origin_path = optional(string)
+      # custom_headers = optional(
+      #   list(
+      #     object({
+      #       name  = string
+      #       value = string
+      #     })
+      #   )
+      # )
+
+      # custom_origin_config = optional(
+      #   object({
+      #     http_port                = number
+      #     https_port               = number
+      #     origin_protocol_policy   = string
+      #     origin_ssl_protocols     = list(string)
+      #     origin_keepalive_timeout = number
+      #     origin_read_timeout      = number
+      #   })
+      # )
+    })
+  )
+
+  default = []
+}
+
 # Restriction variables
 variable "geo_restriction_type" {
   description = "The type of geographic restriction to apply"
   type        = string
   default     = "none"
+}
+
+variable "geo_restriction_locations" {
+  description = <<EOF
+  List of country codes to take action based on the restriction type (e.g.
+  whitelisting or backlisting).
+EOF
+
+  type = list(string)
+
+  # e.g. ["US", "CA", "GB", "DE"]
+  default = []
 }
 
 # Viewer certificate variables

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,12 @@ variable "enabled" {
   default     = true
 }
 
+variable "enable_bucket_policy" {
+  description = "Whether the bucket policy shall be managed or not"
+  type        = bool
+  default     = true
+}
+
 variable "price_class" {
   description = "Price Class"
   type        = string


### PR DESCRIPTION
In our use case we need to change the bucket policy outside this module. There was no easy way to do this with the actual module.
We added a switch with `enable_bucket_policy` defaulting to be true.
Hope this fits into the mainstream module.